### PR TITLE
Add Linux/ARM64 in releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := terraform-provider-stateful
-PLATFORMS := darwin/amd64 linux/amd64
+PLATFORMS := darwin/amd64 linux/amd64 linux/arm64
 VERSION = $(shell git describe 1>/dev/null 2>/dev/null && echo "_$$(git describe)")
 
 temp = $(subst /, ,$@)


### PR DESCRIPTION

Fixes #2 
Added linux/ARM64 in platforms in release section in Makefile

Signed-off-by: odidev <odidev@puresoftware.com>